### PR TITLE
Add privatelink example

### DIFF
--- a/examples/privatelink/README.md
+++ b/examples/privatelink/README.md
@@ -1,0 +1,49 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 4.55.0 |
+| <a name="requirement_skysql"></a> [skysql](#requirement\_skysql) | 1.0.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.55.0 |
+| <a name="provider_skysql"></a> [skysql](#provider\_skysql) | 1.0.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/4.55.0/docs/resources/security_group) | resource |
+| [aws_vpc_endpoint.this](https://registry.terraform.io/providers/hashicorp/aws/4.55.0/docs/resources/vpc_endpoint) | resource |
+| skysql_service.this | resource |
+| [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/4.55.0/docs/data-sources/caller_identity) | data source |
+| [aws_subnets.this](https://registry.terraform.io/providers/hashicorp/aws/4.55.0/docs/data-sources/subnets) | data source |
+| skysql_service.this | data source |
+| skysql_versions.this | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_region"></a> [region](#input\_region) | AWS region | `string` | `"us-east-2"` | no |
+| <a name="input_security_group_cidr_blocks"></a> [security\_group\_cidr\_blocks](#input\_security\_group\_cidr\_blocks) | A list of sources to allow access to privatelink connection via security group | `list(string)` | `[]` | no |
+| <a name="input_skysql_service_name"></a> [skysql\_service\_name](#input\_skysql\_service\_name) | Name of the skysql service being created | `string` | n/a | yes |
+| <a name="input_topology"></a> [topology](#input\_topology) | SkySQL topology type to deploy | `string` | `"es-single"` | no |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | ID of the AWS VPC that will host the privatelink endpoint | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_aws_security_group_id"></a> [aws\_security\_group\_id](#output\_aws\_security\_group\_id) | SkySQL privatelink endpoint service id |
+| <a name="output_skysql_endpoint_service_id"></a> [skysql\_endpoint\_service\_id](#output\_skysql\_endpoint\_service\_id) | SkySQL privatelink endpoint service id |
+| <a name="output_vpc_endpoint_id"></a> [vpc\_endpoint\_id](#output\_vpc\_endpoint\_id) | AWS privatelink endpoint id |
+<!-- END_TF_DOCS -->

--- a/examples/privatelink/main.tf
+++ b/examples/privatelink/main.tf
@@ -1,0 +1,84 @@
+data "aws_caller_identity" "this" {}
+
+data "skysql_versions" "this" {
+  topology = var.topology
+}
+
+###
+# Create the SkySQL service
+###
+resource "skysql_service" "this" {
+  service_type              = "transactional"
+  topology                  = var.topology
+  cloud_provider            = "aws"
+  region                    = var.region
+  name                      = var.skysql_service_name
+  architecture              = "amd64"
+  nodes                     = 1
+  size                      = "sky-2x8"
+  storage                   = 100
+  ssl_enabled               = true
+  version                   = data.skysql_versions.this.versions[0].name
+  endpoint_mechanism        = "privateconnect"
+  endpoint_allowed_accounts = [data.aws_caller_identity.this.account_id]
+  wait_for_creation         = true
+  # The following line will be required when tearing down the skysql service
+  # deletion_protection = false
+}
+
+data "skysql_service" "this" {
+  service_id = skysql_service.this.id
+}
+
+data "aws_subnets" "this" {
+  filter {
+    name   = "vpc-id"
+    values = [var.vpc_id]
+  }
+}
+
+locals {
+  # this should work for all topologies other than lakehouse
+  readwrite_port = [for p in data.skysql_service.this.endpoints[0].ports : p.port if p.purpose == "readwrite"][0]
+}
+
+###
+# Creates the security group that grants access to the privatelink endpoint
+###
+resource "aws_security_group" "this" {
+  name        = var.skysql_service_name
+  description = "Allow access to SkySQL Privatelink endpoint"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port   = local.readwrite_port
+    to_port     = local.readwrite_port
+    protocol    = "tcp"
+    cidr_blocks = var.security_group_cidr_blocks
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+###
+# Create the AWS Privatelink VPC endpoint
+###
+resource "aws_vpc_endpoint" "this" {
+  vpc_id            = var.vpc_id
+  service_name      = data.skysql_service.this.endpoints[0].endpoint_service
+  vpc_endpoint_type = "Interface"
+  subnet_ids        = data.aws_subnets.this.ids
+
+  security_group_ids = [
+    aws_security_group.this.id,
+  ]
+
+  # this is disabled due to dns verification by AWS for privatelink being slow which causes the endpoint creation
+  # to fail.  This can be enabled after a short wait for the dns verification process to complete.
+  private_dns_enabled = false
+}

--- a/examples/privatelink/output.tf
+++ b/examples/privatelink/output.tf
@@ -1,0 +1,14 @@
+output "skysql_endpoint_service_id" {
+  description = "SkySQL privatelink endpoint service id"
+  value       = data.skysql_service.this.endpoints[0].endpoint_service
+}
+
+output "aws_security_group_id" {
+  description = "SkySQL privatelink endpoint service id"
+  value       = aws_security_group.this.id
+}
+
+output "vpc_endpoint_id" {
+  description = "AWS privatelink endpoint id"
+  value       = aws_vpc_endpoint.this.id
+}

--- a/examples/privatelink/providers.tf
+++ b/examples/privatelink/providers.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_providers {
+    skysql = {
+      source  = "registry.terraform.io/mariadb-corporation/skysql"
+      version = "1.0.0"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "4.55.0"
+    }
+  }
+}
+
+provider "skysql" {}
+provider "aws" {
+  region = var.region
+}

--- a/examples/privatelink/variables.tf
+++ b/examples/privatelink/variables.tf
@@ -1,0 +1,27 @@
+variable "topology" {
+  description = "SkySQL topology type to deploy"
+  type        = string
+  default     = "es-single"
+}
+
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-2"
+}
+
+variable "skysql_service_name" {
+  description = "Name of the skysql service being created"
+  type        = string
+}
+
+variable "security_group_cidr_blocks" {
+  description = "A list of sources to allow access to privatelink connection via security group"
+  type        = list(string)
+  default     = []
+}
+
+variable "vpc_id" {
+  description = "ID of the AWS VPC that will host the privatelink endpoint"
+  type        = string
+}


### PR DESCRIPTION
This is an example that can be provided to consumers on how to set up skysql with privatelink in a single terraform stack.

It uses both the AWS and SkySQL terraform providers.

Sample plan:


```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # data.skysql_service.this will be read during apply
  # (config refers to values not yet known)
 <= data "skysql_service" "this" {
      + architecture        = (known after apply)
      + cloud_provider      = (known after apply)
      + created_by          = (known after apply)
      + created_on          = (known after apply)
      + endpoints           = [
        ] -> (known after apply)
      + fqdn                = (known after apply)
      + is_active           = (known after apply)
      + name                = (known after apply)
      + nodes               = (known after apply)
      + nosql_enabled       = (known after apply)
      + outbound_ips        = (known after apply)
      + primary_host        = (known after apply)
      + region              = (known after apply)
      + replication_enabled = (known after apply)
      + service_id          = (known after apply)
      + service_type        = (known after apply)
      + size                = (known after apply)
      + ssl_enabled         = (known after apply)
      + status              = (known after apply)
      + storage_volume      = {
          + iops        = (known after apply)
          + size        = (known after apply)
          + volume_type = (known after apply)
        } -> (known after apply)
      + tier                = (known after apply)
      + topology            = (known after apply)
      + updated_by          = (known after apply)
      + updated_on          = (known after apply)
      + version             = (known after apply)
    }

  # aws_security_group.this will be created
  + resource "aws_security_group" "this" {
      + arn                    = (known after apply)
      + description            = "Allow access to SkySQL Privatelink endpoint"
      + egress                 = [
          + {
              + cidr_blocks      = [
                  + "0.0.0.0/0",
                ]
              + description      = ""
              + from_port        = 0
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "-1"
              + security_groups  = []
              + self             = false
              + to_port          = 0
            },
        ]
      + id                     = (known after apply)
      + ingress                = [
          + {
              + cidr_blocks      = []
              + description      = ""
              + from_port        = (known after apply)
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "tcp"
              + security_groups  = []
              + self             = false
              + to_port          = (known after apply)
            },
        ]
      + name                   = "chuck-xp-20230217-1"
      + name_prefix            = (known after apply)
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + tags_all               = (known after apply)
      + vpc_id                 = "vpc-00555007c8401aba9"
    }

  # aws_vpc_endpoint.this will be created
  + resource "aws_vpc_endpoint" "this" {
      + arn                   = (known after apply)
      + cidr_blocks           = (known after apply)
      + dns_entry             = (known after apply)
      + id                    = (known after apply)
      + ip_address_type       = (known after apply)
      + network_interface_ids = (known after apply)
      + owner_id              = (known after apply)
      + policy                = (known after apply)
      + prefix_list_id        = (known after apply)
      + private_dns_enabled   = false
      + requester_managed     = (known after apply)
      + route_table_ids       = (known after apply)
      + security_group_ids    = (known after apply)
      + service_name          = (known after apply)
      + state                 = (known after apply)
      + subnet_ids            = [
          + "subnet-041ff2642dfbb8b21",
          + "subnet-06a93e57fb993c877",
          + "subnet-0745038a2788ce66f",
        ]
      + tags_all              = (known after apply)
      + vpc_endpoint_type     = "Interface"
      + vpc_id                = "vpc-00555007c8401aba9"

      + dns_options {
          + dns_record_ip_type = (known after apply)
        }
    }

  # skysql_service.this will be created
  + resource "skysql_service" "this" {
      + allow_list                = [
        ] -> (known after apply)
      + architecture              = "amd64"
      + cloud_provider            = "aws"
      + deletion_protection       = true
      + endpoint_allowed_accounts = [
          + "367806877532",
        ]
      + endpoint_mechanism        = "privateconnect"
      + id                        = (known after apply)
      + is_active                 = (known after apply)
      + name                      = "chuck-xp-20230217-1"
      + nodes                     = 1
      + region                    = "us-east-2"
      + service_type              = "transactional"
      + size                      = "sky-4x16"
      + ssl_enabled               = true
      + storage                   = 100
      + topology                  = "xpand"
      + version                   = "6.0.5"
      + wait_for_creation         = true
    }

Plan: 3 to add, 0 to change, 0 to destroy.
```