### PR TITLE
Add psc example

### DIFF
--- a/examples/private-service-connect/README.md
+++ b/examples/private-service-connect/README.md
@@ -1,0 +1,54 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~>1.3.7 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 4.22 |
+| <a name="requirement_skysql"></a> [skysql](#requirement\_skysql) | ~>1.0.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | 4.54.0 |
+| <a name="provider_skysql"></a> [skysql](#provider\_skysql) | 1.0.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_compute_address.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_address) | resource |
+| [google_compute_forwarding_rule.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_forwarding_rule) | resource |
+| [google_dns_managed_zone.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_managed_zone) | resource |
+| [google_dns_record_set.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_record_set) | resource |
+| skysql_service.this | resource |
+| [google_compute_network.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_network) | data source |
+| [google_project.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |
+| skysql_service.this | data source |
+| skysql_versions.this | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_link_dns"></a> [link\_dns](#input\_link\_dns) | Flag to enable private dns resolution of the skysql domain name | `bool` | `true` | no |
+| <a name="input_network"></a> [network](#input\_network) | VPC network to connect to skysql service | `string` | `"default"` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project id | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | GCP region | `string` | `"us-central1"` | no |
+| <a name="input_skysql_service_name"></a> [skysql\_service\_name](#input\_skysql\_service\_name) | Name of the skysql service being created | `string` | n/a | yes |
+| <a name="input_subnetwork"></a> [subnetwork](#input\_subnetwork) | VPC subnetwork to connect to skysql service | `string` | `"default"` | no |
+| <a name="input_topology"></a> [topology](#input\_topology) | SkySQL topology type to deploy | `string` | `"es-single"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_psc_address"></a> [psc\_address](#output\_psc\_address) | Private IP address assigned to the PSC endpoint |
+| <a name="output_skysql_endpoint_service_id"></a> [skysql\_endpoint\_service\_id](#output\_skysql\_endpoint\_service\_id) | SkySQL privatelink endpoint service id |
+| <a name="output_skysql_host"></a> [skysql\_host](#output\_skysql\_host) | Hostname for private database connections |
+<!-- END_TF_DOCS -->

--- a/examples/private-service-connect/main.tf
+++ b/examples/private-service-connect/main.tf
@@ -1,0 +1,90 @@
+data "google_project" "this" {}
+
+data "skysql_versions" "this" {
+  topology = var.topology
+}
+
+###
+# Create the SkySQL service
+###
+resource "skysql_service" "this" {
+  service_type              = "transactional"
+  topology                  = var.topology
+  cloud_provider            = "gcp"
+  region                    = var.region
+  name                      = var.skysql_service_name
+  architecture              = "amd64"
+  nodes                     = 1
+  size                      = "sky-2x8"
+  storage                   = 100
+  ssl_enabled               = true
+  version                   = data.skysql_versions.this.versions[0].name
+  endpoint_mechanism        = "privateconnect"
+  endpoint_allowed_accounts = [data.google_project.this.number]
+  wait_for_creation         = true
+  # The following line will be required when tearing down the skysql service
+  # deletion_protection = false
+}
+
+data "skysql_service" "this" {
+  service_id = skysql_service.this.id
+}
+
+locals {
+  # this should work for all topologies other than lakehouse
+  readwrite_port = [for p in data.skysql_service.this.endpoints[0].ports : p.port if p.purpose == "readwrite"][0]
+  skysql_domain  = "db.skysql.net"
+}
+
+
+###
+# Creates the private address and forwarding rule for the PSC endpoint
+###
+resource "google_compute_address" "this" {
+  name         = var.skysql_service_name
+  address_type = "INTERNAL"
+  subnetwork   = var.subnetwork
+  project      = var.project_id
+  region       = var.region
+}
+
+resource "google_compute_forwarding_rule" "this" {
+  name                  = "psc-${var.skysql_service_name}"
+  load_balancing_scheme = ""
+  region                = var.region
+  project               = var.project_id
+  ip_address            = google_compute_address.this.id
+  target                = data.skysql_service.this.endpoints[0].endpoint_service
+  network               = var.network
+}
+
+
+###
+# Create the private DNS zone and record for skysql dns resolution within the private network
+###
+data "google_compute_network" "this" {
+  name = var.network
+}
+
+resource "google_dns_managed_zone" "this" {
+  count       = var.link_dns ? 1 : 0
+  name        = "skysql-psc"
+  dns_name    = "${local.skysql_domain}."
+  description = "SkySQL PSC forwarding zone"
+  visibility  = "private"
+
+  private_visibility_config {
+    networks {
+      network_url = data.google_compute_network.this.id
+    }
+  }
+}
+
+resource "google_dns_record_set" "this" {
+  count        = var.link_dns ? 1 : 0
+  managed_zone = google_dns_managed_zone.this[0].name
+  name         = "${data.skysql_service.this.fqdn}."
+  type         = "A"
+  ttl          = 300
+  rrdatas      = [google_compute_address.this.address]
+}

--- a/examples/private-service-connect/outputs.tf
+++ b/examples/private-service-connect/outputs.tf
@@ -1,0 +1,14 @@
+output "skysql_endpoint_service_id" {
+  description = "SkySQL privatelink endpoint service id"
+  value       = data.skysql_service.this.endpoints[0].endpoint_service
+}
+
+output "psc_address" {
+  description = "Private IP address assigned to the PSC endpoint"
+  value       = google_compute_address.this.address
+}
+
+output "skysql_host" {
+  description = "Hostname for private database connections"
+  value       = var.link_dns ? data.skysql_service.this.fqdn : google_compute_address.this.address
+}

--- a/examples/private-service-connect/providers.tf
+++ b/examples/private-service-connect/providers.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_version = "~>1.3.7"
+  required_providers {
+    skysql = {
+      source  = "registry.terraform.io/mariadb-corporation/skysql"
+      version = "~>1.0.0"
+    }
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.22"
+    }
+
+  }
+}
+
+provider "skysql" {}
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}

--- a/examples/private-service-connect/variables.tf
+++ b/examples/private-service-connect/variables.tf
@@ -1,0 +1,39 @@
+variable "topology" {
+  description = "SkySQL topology type to deploy"
+  type        = string
+  default     = "es-single"
+}
+
+variable "project_id" {
+  description = "GCP project id"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "skysql_service_name" {
+  description = "Name of the skysql service being created"
+  type        = string
+}
+
+variable "network" {
+  description = "VPC network to connect to skysql service"
+  type        = string
+  default     = "default"
+}
+
+variable "subnetwork" {
+  description = "VPC subnetwork to connect to skysql service"
+  type        = string
+  default     = "default"
+}
+
+variable "link_dns" {
+  description = "Flag to enable private dns resolution of the skysql domain name"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
This is an example for setting up private service connect with skysql and the GCP terraform providers.

Sample plan:
```
Terraform will perform the following actions:

  # data.skysql_service.this will be read during apply
  # (config refers to values not yet known)
 <= data "skysql_service" "this" {
      + architecture        = (known after apply)
      + cloud_provider      = (known after apply)
      + created_by          = (known after apply)
      + created_on          = (known after apply)
      + endpoints           = [
        ] -> (known after apply)
      + fqdn                = (known after apply)
      + is_active           = (known after apply)
      + name                = (known after apply)
      + nodes               = (known after apply)
      + nosql_enabled       = (known after apply)
      + outbound_ips        = (known after apply)
      + primary_host        = (known after apply)
      + region              = (known after apply)
      + replication_enabled = (known after apply)
      + service_id          = (known after apply)
      + service_type        = (known after apply)
      + size                = (known after apply)
      + ssl_enabled         = (known after apply)
      + status              = (known after apply)
      + storage_volume      = {
          + iops        = (known after apply)
          + size        = (known after apply)
          + volume_type = (known after apply)
        } -> (known after apply)
      + tier                = (known after apply)
      + topology            = (known after apply)
      + updated_by          = (known after apply)
      + updated_on          = (known after apply)
      + version             = (known after apply)
    }

  # google_compute_address.this will be created
  + resource "google_compute_address" "this" {
      + address            = (known after apply)
      + address_type       = "INTERNAL"
      + creation_timestamp = (known after apply)
      + id                 = (known after apply)
      + name               = "chuck-tx-20230223-3"
      + network_tier       = (known after apply)
      + project            = "mdb-cnewport"
      + purpose            = (known after apply)
      + region             = "us-central1"
      + self_link          = (known after apply)
      + subnetwork         = "default"
      + users              = (known after apply)
    }

  # google_compute_forwarding_rule.this will be created
  + resource "google_compute_forwarding_rule" "this" {
      + creation_timestamp    = (known after apply)
      + id                    = (known after apply)
      + ip_address            = (known after apply)
      + ip_protocol           = (known after apply)
      + label_fingerprint     = (known after apply)
      + name                  = "psc-chuck-tx-20230223-3"
      + network               = "default"
      + network_tier          = (known after apply)
      + project               = "mdb-cnewport"
      + psc_connection_id     = (known after apply)
      + psc_connection_status = (known after apply)
      + region                = "us-central1"
      + self_link             = (known after apply)
      + service_name          = (known after apply)
      + subnetwork            = (known after apply)
      + target                = (known after apply)

      + service_directory_registrations {
          + namespace = (known after apply)
          + service   = (known after apply)
        }
    }

  # google_dns_managed_zone.this[0] will be created
  + resource "google_dns_managed_zone" "this" {
      + creation_time   = (known after apply)
      + description     = "SkySQL PSC forwarding zone"
      + dns_name        = "db.skysql.net."
      + force_destroy   = false
      + id              = (known after apply)
      + managed_zone_id = (known after apply)
      + name            = "skysql-psc"
      + name_servers    = (known after apply)
      + project         = (known after apply)
      + visibility      = "private"

      + cloud_logging_config {
          + enable_logging = (known after apply)
        }

      + private_visibility_config {

          + networks {
              + network_url = "projects/mdb-cnewport/global/networks/default"
            }
        }
    }

  # google_dns_record_set.this[0] will be created
  + resource "google_dns_record_set" "this" {
      + id           = (known after apply)
      + managed_zone = "skysql-psc"
      + name         = (known after apply)
      + project      = (known after apply)
      + rrdatas      = (known after apply)
      + ttl          = 300
      + type         = "A"
    }

  # skysql_service.this will be created
  + resource "skysql_service" "this" {
      + allow_list                = [
        ] -> (known after apply)
      + architecture              = "amd64"
      + cloud_provider            = "gcp"
      + deletion_protection       = true
      + endpoint_allowed_accounts = [
          + "1059564612314",
        ]
      + endpoint_mechanism        = "privateconnect"
      + id                        = (known after apply)
      + is_active                 = (known after apply)
      + name                      = "chuck-tx-20230223-3"
      + nodes                     = 1
      + region                    = "us-central1"
      + service_type              = "transactional"
      + size                      = "sky-2x8"
      + ssl_enabled               = true
      + storage                   = 100
      + topology                  = "es-single"
      + version                   = "10.6.11-6-1"
      + wait_for_creation         = true
    }

Plan: 5 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + psc_address                = (known after apply)
  + skysql_endpoint_service_id = (known after apply)
  + skysql_host                = (known after apply)
```